### PR TITLE
주소 커스텀 함수 수정

### DIFF
--- a/src/utils/CustomAddress.ts
+++ b/src/utils/CustomAddress.ts
@@ -2,6 +2,9 @@
 
 export const CustomAddress = (address: string) => {
   const withoutNumber = address.replace(/\[\d+\]\s*/, "");
-  const parts = withoutNumber.split(" ");
+
+  const normalized = withoutNumber.replace(/(특별자치도|특별시|광역시|자치시)/, "").replace(/도$/, "");
+
+  const parts = normalized.split(" ");
   return parts.slice(0, 2).join(" ");
 };


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #167

## ✅ 작업 사항
- 특별자치도, 특별시, 광역시 등 수식어 제거하고 기본 행정구역만 남기도록 수정
- "도"로 끝나는 경우도 제거

## 💡 예시
- 강원특별자치도 춘천시 ➡ 강원 춘천시
- 세종특별자치시 조치원읍 ➡ 세종 조치원읍
- 경기도 성남시 ➡ 경기 성남시

## 🧑‍💻 기타
- 기존에 있던 주소 커스텀 함수에서 로직만 변경

